### PR TITLE
prepare new release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.2.0 (2023/07/24)
+
+- migration to turbo module
+- FIX: siteId integer not being correctly handled
+- update docs and types
+- export types
+
 ## 0.1.0 (2023/07/04)
 
 - Initial version


### PR DESCRIPTION
## 0.2.0 

- migration to turbo module
- FIX: siteId integer not being correctly handled
- update docs and types
- export types